### PR TITLE
Added inheritance flexibility to ModelBackend

### DIFF
--- a/django_odesk/auth/backends.py
+++ b/django_odesk/auth/backends.py
@@ -101,13 +101,18 @@ class BaseModelBackend(ModelBackend):
 
     create_unknown_user = True
     
-    def __init__(self):
-        pass
+    def __init__(self, *args, **kwargs):
+        super(BaseModelBackend, self).__init__(*args, **kwargs)
+        self.api_token = None
+        self.auth_user = None
+        self.client = None
 
     def authenticate(self, token=None):
         client = DefaultClient(token)
+        self.client = client
         try:
             api_token, auth_user = client.auth.check_token()
+            self.api_token, self.auth_user = api_token, auth_user
         except HTTPError:
             return None
 
@@ -200,8 +205,10 @@ class TeamAuthBackend(ModelBackend):
 
     def authenticate(self, token=None):
         client = DefaultClient(token)
+        self.client = client
         try:
             api_token, auth_user = client.auth.check_token()
+            self.api_token, self.auth_user = api_token, auth_user
         except HTTPError:
             return None
 

--- a/django_odesk/auth/backends.py
+++ b/django_odesk/auth/backends.py
@@ -100,6 +100,9 @@ class SimpleBackend(object):
 class BaseModelBackend(ModelBackend):
 
     create_unknown_user = True
+    
+    def __init__(self):
+        pass
 
     def authenticate(self, token=None):
         client = DefaultClient(token)


### PR DESCRIPTION
Now client, api_token and auth_user are ModelBackend object fields, not just local method variables. This adds possibility to inherit ModelBackend, override authenticate() method, call parent one and then use self.auth_user field. 

Usage example: in purpose of timezone saving, inherit ModelBackend, add 

user.get_profile().timezone = auth_user['timezone']

to overridden authenticate() method just after parent method call.
